### PR TITLE
Spec out tempid separately, including DbId instance, and add tests

### DIFF
--- a/src/cljc/lab79/datomic_spec.cljc
+++ b/src/cljc/lab79/datomic_spec.cljc
@@ -5,7 +5,7 @@
             [clojure.string :refer [starts-with?]]
             #?(:clj  [clojure.spec.gen :as gen]
                :cljs [cljs.spec.impl.gen :as gen]))
-  #?(:clj (:import (datomic.db Db))))
+  #?(:clj (:import (datomic.db Db DbId))))
 
 (def datomic-value-types
   #{:db.type/string :db.type/boolean :db.type/long :db.type/bigint :db.type/float :db.type/double :db.type/bigdec
@@ -20,12 +20,17 @@
 ;
 
 #?(:clj (s/def ::db #(instance? Db %)))
+
+(s/def ::tempid
+  (s/or
+    #?@(:clj [:dbid #(instance? DbId %)])
+    :string (s/and string? #(not (starts-with? % ":")))))
 (s/def :db/id
   (s/or
     :lookup-ref (s/tuple keyword? (s/or :string string?
                                         :int integer?
                                         :uuid uuid?))
-    :string (s/and string? #(not (starts-with? % ":")))
+    :tempid ::tempid
     :ident keyword?))
 (s/def :db/ident (s/with-gen keyword? #(tcgen/resize 2 (gen/keyword-ns))))
 (s/def :db/valueType datomic-value-types)

--- a/src/cljc/lab79/datomic_spec.cljc
+++ b/src/cljc/lab79/datomic_spec.cljc
@@ -27,6 +27,7 @@
     :string (s/and string? #(not (starts-with? % ":")))))
 (s/def :db/id
   (s/or
+    :entity-id number?
     :lookup-ref (s/tuple keyword? (s/or :string string?
                                         :int integer?
                                         :uuid uuid?))

--- a/test/datomic_spec/core_test.clj
+++ b/test/datomic_spec/core_test.clj
@@ -32,13 +32,23 @@
 
 (deftest db-id-test
   (testing "::tempid"
-    (is (s/valid? :lab79.datomic-spec/tempid #db/id[:db.part/user])))
+    (is (= (first (s/conform :lab79.datomic-spec/tempid #db/id[:db.part/user]))
+           :dbid)
+        "DbId tempid")
+    (is (= (first (s/conform :lab79.datomic-spec/tempid "tempid")) :string)
+        "String tempid"))
+
   (testing ":db/id"
-    (is (s/valid? :db/id [:user "foo"]) "Lookup ref")
-    (is (s/valid? :db/id "tempid") "tempid string")
-    (is (s/valid? :db/id #db/id[:db.part/user]) "tempid DbId")
+
+    (is (= (first (s/conform :db/id 123123123)) :entity-id))
+
+    (is (= (first (s/conform :db/id [:user "foo"])) :lookup-ref))
+
+    (is (= (first (s/conform :db/id "tempid")) :tempid))
+    (is (= (first (s/conform :db/id #db/id[:db.part/user])) :tempid))
     (is (not (s/valid? :db/id ":tempid")) "bad tempid")
-    (is (s/valid? :db/id :my/ident) "Ident")))
+
+    (is (= (first (s/conform :db/id :my/ident)) :ident))))
 
 (deftest datalog-vars
   (testing "src vars"

--- a/test/datomic_spec/core_test.clj
+++ b/test/datomic_spec/core_test.clj
@@ -30,6 +30,16 @@
       (fn [conn] (is (s/valid? :lab79.datomic-spec/db (d/db conn)))))
     (is (not (s/valid? :lab79.datomic-spec/db :foo)))))
 
+(deftest db-id-test
+  (testing "::tempid"
+    (is (s/valid? :lab79.datomic-spec/tempid #db/id[:db.part/user])))
+  (testing ":db/id"
+    (is (s/valid? :db/id [:user "foo"]) "Lookup ref")
+    (is (s/valid? :db/id "tempid") "tempid string")
+    (is (s/valid? :db/id #db/id[:db.part/user]) "tempid DbId")
+    (is (not (s/valid? :db/id ":tempid")) "bad tempid")
+    (is (s/valid? :db/id :my/ident) "Ident")))
+
 (deftest datalog-vars
   (testing "src vars"
     (is (s/valid? :datalog/src-var '$))


### PR DESCRIPTION
- adds `:entity-id number?` as a valid `:db/id`
- separates out `::tempid` into a separate spec
- specs tempid literals `#db/id[:db.part/user]` as valid `::tempid`s (for clj only) via `#?@(:clj [:dbid #(instance? DbId %)])`
- adds tests for both `:db/id` and `::tempid` specs
